### PR TITLE
Set: High Priority Based on MultiWords Contains for Search

### DIFF
--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -83,6 +83,33 @@ class SearchRunner
         }
 
         //  Set High Priority Based on mutltiwords Contains
+        // Results Stores this Arrays
+        // Pages Array
+        // "name" => "Non temporibus consequatur necessitatibus eos maiores et consequatur velit."
+        // "id" => 4022
+        // "slug" => "QICRblceCl"
+        // "book_id" => 7
+        // "chapter_id" => 103
+        // "draft" => 0
+        // "template" => 0
+        // "text" => "Repellendus sunt rerum perspiciatis et debitis aut laboriosam. Et veniam earum in quidem. Esse porro quisquam ipsam praesentium voluptatibus quasi officiis. Et nam eaque omnis ut. Ex occaecati aliquam dignissimos perferendis.Voluptatem nesciunt magnam quisquam enim autem. Quia nobis rerum voluptas eaque velit. Sed suscipit corporis ad qui. Omnis autem fugit ut qui velit impedit magni.Ut sequi magnam nemo eaque. Iste qui ipsam nobis. Recusandae dolores maxime praesentium quo esse architecto. Laborum quos tenetur nobis ducimus quas vero.Et sed et ut nihil impedit aut quasi. Et sint asperiores dolores rem sed aut id. Placeat cupiditate nemo quam. Molestiae aut provident quisquam sed quis.Doloribus quia accusamus dolore vel est voluptatem facere quo. Voluptatem officia sint sapiente dolorem officiis. Alias sunt facilis et doloribus."
+        // "created_at" => "2024-09-19 13:11:47"
+        // "updated_at" => "2024-09-19 13:11:47"
+        // "priority" => 0
+        // "owned_by" => 0
+        // "book_slug" => "eAIqN4dcnl"
+        // "score" => "46.53342"
+
+        //Book, Chapter, bookshelves Array
+        // "id" => 10
+        // "slug" => "j0YTXNaUVf"
+        // "name" => "Officiis magni illum laudantium enim earum dolor velit."
+        // "description" => "Consequatur aut nihil sunt enim id. Quo at odio inventore consectetur harum."
+        // "created_at" => "2024-09-19 13:11:18"
+        // "updated_at" => "2024-09-19 13:11:18"
+        // "image_id" => null
+        // "owned_by" => 3
+        // "score" => "26.05248"
         foreach ($results as $result) {
             $flag = 0;
 
@@ -101,7 +128,7 @@ class SearchRunner
 
             $result->wordScore = $flag;
         }
-
+        
         return [
             'total'    => $total,
             'count'    => count($results),

--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -82,11 +82,31 @@ class SearchRunner
             $results = $results->merge($searchResults);
         }
 
+        //  Set High Priority Based on mutltiwords Contains
+        foreach ($results as $result) {
+            $flag = 0;
+
+            foreach ($searchOpts->searches as $searchoption) {
+                if ($result->first()->getTable() === 'pages') {
+                    if (strpos(strtolower($result->name), strtolower($searchoption)) !== false || strpos(strtolower($result->text), strtolower($searchoption)) !== false) {
+                        $flag++;
+                        
+                    }
+                } else {
+                    if (strpos(strtolower($result->name), strtolower($searchoption)) !== false || strpos(strtolower($result->description), strtolower($searchoption)) !== false) {
+                        $flag++;
+                    }
+                }
+            }
+
+            $result->wordScore = $flag;
+        }
+
         return [
             'total'    => $total,
             'count'    => count($results),
             'has_more' => $hasMore,
-            'results'  => $results->sortByDesc('score')->values(),
+            'results'  => $results->sortByDesc(['wordScore','score'])->values(),
         ];
     }
 

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -426,6 +426,24 @@ class EntitySearchTest extends TestCase
         $this->withHtml($search)->assertElementContains('.entity-list > .page:nth-child(2)', 'Test page A');
     }
 
+    public function test_mutliwords_contains_page_have_high_order()
+    {
+        $this->entities->newPage(['name'=>'Test page 1','html'=>'<p>Hello how r u? i am fine, what about you</p>']);
+        $this->entities->newPage(['name'=>'Test page 2','html'=>'<p>what going on?</p>']);
+        $this->entities->newPage(['name'=>'Test page 3','html'=>'<p>what are you doing?</p>']);
+        $this->entities->newBook(['name'=>'test book','description'=>'what is testing']);
+
+        $search = $this->asEditor()->get('/search?term='.urlencode('what you'));
+
+        $wordScoreByTerm = $search->baseResponse->original->getData()['entities']->pluck('wordScore', 'name');
+        
+        $this->assertEquals(2,$wordScoreByTerm->get('Test page 1'));
+        $this->assertEquals(2,$wordScoreByTerm->get('Test page 3'));
+        $this->assertEquals(1,$wordScoreByTerm->get('Test page 2'));
+        $this->assertEquals(1,$wordScoreByTerm->get('test book'));
+
+    }
+
     public function test_terms_in_headers_have_an_adjusted_index_score()
     {
         $page = $this->entities->newPage(['name' => 'Test page A', 'html' => '


### PR DESCRIPTION
closes #2 

Set priority for multiple words in a search.

If we search for 3 words:

- The results that contain all 3 words should appear first in the search list.
- Results containing 2 of the 3 words should appear next.
- Finally, results containing only 1 of the 3 words should follow.


#2 