### PR TITLE
Assign the default editor value while initial page creation

### DIFF
--- a/app/Entities/Repos/PageRepo.php
+++ b/app/Entities/Repos/PageRepo.php
@@ -57,6 +57,13 @@ class PageRepo
             $page->forceFill([
                 'html'  => $defaultTemplate->html,
                 'markdown' => $defaultTemplate->markdown,
+                'editor' => 'markdown',
+            ]);
+        }
+        // assigning the default value to draft at the time of draft creation
+        else {
+            $page->forceFill([
+                'editor' => 'wysiwyg',
             ]);
         }
 

--- a/database/migrations/2024_09_24_131122_update_editor_values_in_pages_table.php
+++ b/database/migrations/2024_09_24_131122_update_editor_values_in_pages_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            
+        // We set it to 'markdown' for pages currently with markdown content
+        DB::table('pages')->where('markdown', '!=', '')->update(['editor' => 'markdown']);
+        // We set it to 'wysiwyg' where we have HTML but no markdown
+        DB::table('pages')->where('markdown', '=', '')
+            ->where('html', '!=', '')
+            ->update(['editor' => 'wysiwyg']);
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bookstack",
+  "name": "BookStack",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
assign the default editor value "wysiwyg" on page creation 

Add the migration to update the editor value of current pages so that the editor value is set for previously created page.

now onwards while creating the new page the editor value is set

#1 