### PR TITLE
Add: imagagick library and imagick php extension for fix the issue th…

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -7,18 +7,26 @@ RUN <<EOR
 # Install additional dependencies
 apt-get update
 apt-get install -y \
-	git \
-	zip \
-	unzip \
-	libpng-dev \
-	libldap2-dev \
-	libzip-dev \
-	wait-for-it
+    git \
+    zip \
+    unzip \
+    libpng-dev \
+    libjpeg62-turbo-dev \
+    libfreetype6-dev \
+    libwebp-dev \
+    libldap2-dev \
+    libzip-dev \
+    imagemagick \
+    libmagickwand-dev \
+    wait-for-it
 rm -rf /var/lib/apt/lists/*
 
-# Configure apache
-docker-php-ext-configure ldap --with-libdir="lib/$(gcc -dumpmachine)"
+docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp
 docker-php-ext-install pdo_mysql gd ldap zip
+
+pecl install imagick
+docker-php-ext-enable imagick
+
 pecl install xdebug
 docker-php-ext-enable xdebug
 a2enmod rewrite


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue : Support Webp images in DomPDF exports

<!-- Remove this section if not applicable -->

Closes #6 

## Changes proposed

<!-- List all the proposed changes in your PR -->

For allow webp images and other images in pages and that pages should be export as pdf properly
1. Add ImageMagick library and add required library for imagemagick 
2. Enable Extension imagick for images 

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

Problem : 
![62195724-40c22b80-b385-11e9-8a72-7ee08c954497](https://github.com/user-attachments/assets/69704e86-4dd8-449d-b4d2-79d4cb739350)

Solution: 
![Suppport webp solution](https://github.com/user-attachments/assets/6a04bb09-1c4e-4cf0-84fc-0e9d16cef509)


## Note to reviewers

<!-- Add notes to reviewers if applicable -->
