### PR TITLE
Add: Ability to merge firstname and lastname when fullname is not the…

### DIFF
--- a/app/Access/LdapService.php
+++ b/app/Access/LdapService.php
@@ -83,7 +83,7 @@ class LdapService
         $emailAttr = $this->config['email_attribute'];
         $displayNameAttr = $this->config['display_name_attribute'];
         $firstName = explode(',', $displayNameAttr)[0];
-        $lastName = explode(',', $displayNameAttr)[0];
+        $lastName = explode(',', $displayNameAttr)[1];
         $thumbnailAttr = $this->config['thumbnail_attribute'];
 
         $user = $this->getUserWithAttributes($userName, array_filter([

--- a/app/Access/LdapService.php
+++ b/app/Access/LdapService.php
@@ -96,8 +96,7 @@ class LdapService
 
         $userCn = $this->getUserResponseProperty($user, 'cn', null);
 
-        if ($userCn === null) 
-        {
+        if ($userCn === null) {
             $userCn = $this->getUserResponseProperty($user, $firstName, null) . ' ' . $this->getUserResponseProperty($user, $lastName, null);
         }
 

--- a/app/Access/LdapService.php
+++ b/app/Access/LdapService.php
@@ -82,17 +82,25 @@ class LdapService
         $idAttr = $this->config['id_attribute'];
         $emailAttr = $this->config['email_attribute'];
         $displayNameAttr = $this->config['display_name_attribute'];
+        $firstName = explode(',',$displayNameAttr)[0];
+        $lastName = explode(',',$displayNameAttr)[0];
         $thumbnailAttr = $this->config['thumbnail_attribute'];
 
         $user = $this->getUserWithAttributes($userName, array_filter([
-            'cn', 'dn', $idAttr, $emailAttr, $displayNameAttr, $thumbnailAttr,
+            'cn', 'dn', $idAttr, $emailAttr, $firstName,$lastName, $thumbnailAttr,
         ]));
 
         if (is_null($user)) {
             return null;
         }
-
+        
         $userCn = $this->getUserResponseProperty($user, 'cn', null);
+
+        if($userCn === null)
+        {
+            $userCn = $this->getUserResponseProperty($user, $firstName, null) . ' ' . $this->getUserResponseProperty($user, $lastName, null);
+        }
+
         $formatted = [
             'uid'   => $this->getUserResponseProperty($user, $idAttr, $user['dn']),
             'name'  => $this->getUserResponseProperty($user, $displayNameAttr, $userCn),

--- a/app/Access/LdapService.php
+++ b/app/Access/LdapService.php
@@ -96,10 +96,10 @@ class LdapService
 
         $userCn = $this->getUserResponseProperty($user, 'cn', null);
 
-        if ($userCn === null)
+        if ($userCn === null) 
         {
             $userCn = $this->getUserResponseProperty($user, $firstName, null) . ' ' . $this->getUserResponseProperty($user, $lastName, null);
-        } 
+        }
 
         $formatted = [
             'uid'   => $this->getUserResponseProperty($user, $idAttr, $user['dn']),

--- a/app/Access/LdapService.php
+++ b/app/Access/LdapService.php
@@ -82,8 +82,8 @@ class LdapService
         $idAttr = $this->config['id_attribute'];
         $emailAttr = $this->config['email_attribute'];
         $displayNameAttr = $this->config['display_name_attribute'];
-        $firstName = explode(',',$displayNameAttr)[0];
-        $lastName = explode(',',$displayNameAttr)[0];
+        $firstName = explode(',', $displayNameAttr)[0];
+        $lastName = explode(',', $displayNameAttr)[0];
         $thumbnailAttr = $this->config['thumbnail_attribute'];
 
         $user = $this->getUserWithAttributes($userName, array_filter([
@@ -93,13 +93,13 @@ class LdapService
         if (is_null($user)) {
             return null;
         }
-        
+
         $userCn = $this->getUserResponseProperty($user, 'cn', null);
 
-        if($userCn === null)
+        if ($userCn === null)
         {
             $userCn = $this->getUserResponseProperty($user, $firstName, null) . ' ' . $this->getUserResponseProperty($user, $lastName, null);
-        }
+        } 
 
         $formatted = [
             'uid'   => $this->getUserResponseProperty($user, $idAttr, $user['dn']),

--- a/tests/Auth/LdapTest.php
+++ b/tests/Auth/LdapTest.php
@@ -653,13 +653,13 @@ class LdapTest extends TestCase
                 'sn' => [$this->mockUser->lastName],
                 'dn'  => 'dc=test' . config('services.ldap.base_dn'),
             ]]);
-            
+
         $this->mockUserLogin()->assertRedirect('/login');
         $this->get('/login')->assertSee('Please enter an email to use for this account.');
-        
+
         $resp = $this->mockUserLogin($this->mockUser->email);
         $resp->assertRedirect('/');
-        
+
         $expectedDisplayName = $this->mockUser->firstName . ' ' . $this->mockUser->lastName;
 
         $this->get('/')->assertSee($expectedDisplayName);

--- a/tests/Auth/LdapTest.php
+++ b/tests/Auth/LdapTest.php
@@ -29,7 +29,7 @@ class LdapTest extends TestCase
             'auth.defaults.guard'                  => 'ldap',
             'services.ldap.base_dn'                => 'dc=ldap,dc=local',
             'services.ldap.email_attribute'        => 'mail',
-            'services.ldap.display_name_attribute' => 'givenName',
+            'services.ldap.display_name_attribute' => 'cn',
             'services.ldap.id_attribute'           => 'uid',
             'services.ldap.user_to_groups'         => false,
             'services.ldap.version'                => '3',
@@ -633,6 +633,46 @@ class LdapTest extends TestCase
             'name'             => $this->mockUser->name,
         ]);
     }
+
+    public function test_login_uses_givenName_and_sn_merge_if_display_name_is_not_present()
+    {
+        app('config')->set([
+            'services.ldap.display_name_attribute' => 'displayName',
+        ]);
+
+        $this->mockUser->firstName = explode(" ", $this->mockUser->name)[0];
+        $this->mockUser->lastName = explode(" ", $this->mockUser->name)[1];
+
+        $this->commonLdapMocks(1, 1, 2, 4, 2);
+        $this->mockLdap->shouldReceive('searchAndGetEntries')->times(2)
+            ->with($this->resourceId, config('services.ldap.base_dn'), \Mockery::type('string'), \Mockery::type('array'))
+            ->andReturn(['count' => 1, 0 => [
+                'uid' => [$this->mockUser->name],
+                'cn'  => [$this->mockUser->name],
+                'givenName' => [$this->mockUser->firstName],
+                'sn' => [$this->mockUser->lastName],
+                'dn'  => 'dc=test' . config('services.ldap.base_dn'),
+            ]]);
+            
+        $this->mockUserLogin()->assertRedirect('/login');
+        $this->get('/login')->assertSee('Please enter an email to use for this account.');
+        
+        $resp = $this->mockUserLogin($this->mockUser->email);
+        $resp->assertRedirect('/');
+        
+        $expectedDisplayName = $this->mockUser->firstName . ' ' . $this->mockUser->lastName;
+
+        $this->get('/')->assertSee($expectedDisplayName);
+
+        $this->assertDatabaseHas('users', [
+            'email'            => $this->mockUser->email,
+            'email_confirmed'  => false,
+            'external_auth_id' => $this->mockUser->name,
+            'name'             => $this->mockUser->name,
+        ]);
+    }
+
+
 
     protected function checkLdapReceivesCorrectDetails($serverString, $expectedHostString): void
     {

--- a/tests/Auth/LdapTest.php
+++ b/tests/Auth/LdapTest.php
@@ -29,7 +29,7 @@ class LdapTest extends TestCase
             'auth.defaults.guard'                  => 'ldap',
             'services.ldap.base_dn'                => 'dc=ldap,dc=local',
             'services.ldap.email_attribute'        => 'mail',
-            'services.ldap.display_name_attribute' => 'cn',
+            'services.ldap.display_name_attribute' => 'givenName',
             'services.ldap.id_attribute'           => 'uid',
             'services.ldap.user_to_groups'         => false,
             'services.ldap.version'                => '3',
@@ -590,6 +590,8 @@ class LdapTest extends TestCase
             ->andReturn(['count' => 1, 0 => [
                 'uid'         => [$this->mockUser->name],
                 'cn'          => [$this->mockUser->name],
+                'givenName'   => [explode(" ",$this->mockUser)[0]],
+                'sn'          => [explode(" ",$this->mockUser)[1]],
                 'dn'          => 'dc=test' . config('services.ldap.base_dn'),
                 'displayname' => 'displayNameAttribute',
             ]]);

--- a/tests/Auth/LdapTest.php
+++ b/tests/Auth/LdapTest.php
@@ -590,8 +590,8 @@ class LdapTest extends TestCase
             ->andReturn(['count' => 1, 0 => [
                 'uid'         => [$this->mockUser->name],
                 'cn'          => [$this->mockUser->name],
-                'givenName'   => [explode(" ",$this->mockUser)[0]],
-                'sn'          => [explode(" ",$this->mockUser)[1]],
+                'givenName'   => [explode(" ", $this->mockUser)[0]],
+                'sn'          => [explode(" ", $this->mockUser)[1]],
                 'dn'          => 'dc=test' . config('services.ldap.base_dn'),
                 'displayname' => 'displayNameAttribute',
             ]]);


### PR DESCRIPTION

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->
Closes #11

## Fixes Issue : LDAP_DISPLAY_NAME_ATTRIBUTE merge multiple values

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

- Add Ability to merge two values firstname as givenName and lastname as sn when fullname is not there in LDAP
- In Test case add firstname as givenName and lastname as sn

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
