### PR TITLE
Add Attachment search functionality by content type in search

### DIFF
--- a/app/App/Providers/AppServiceProvider.php
+++ b/app/App/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ use BookStack\Exceptions\BookStackExceptionHandlerPage;
 use BookStack\Http\HttpRequestService;
 use BookStack\Permissions\PermissionApplicator;
 use BookStack\Settings\SettingService;
+use BookStack\Uploads\Attachment;
 use BookStack\Util\CspService;
 use Illuminate\Contracts\Foundation\ExceptionRenderer;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -73,6 +74,7 @@ class AppServiceProvider extends ServiceProvider
             'book'      => Book::class,
             'chapter'   => Chapter::class,
             'page'      => Page::class,
+            'attachment' => Attachment::class,
         ]);
     }
 }

--- a/app/Entities/EntityProvider.php
+++ b/app/Entities/EntityProvider.php
@@ -8,6 +8,7 @@ use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Models\Entity;
 use BookStack\Entities\Models\Page;
 use BookStack\Entities\Models\PageRevision;
+use BookStack\Uploads\Attachment;
 
 /**
  * Class EntityProvider.
@@ -23,6 +24,7 @@ class EntityProvider
     public Chapter $chapter;
     public Page $page;
     public PageRevision $pageRevision;
+    public Attachment $attachment;
 
     public function __construct()
     {
@@ -31,6 +33,7 @@ class EntityProvider
         $this->chapter = new Chapter();
         $this->page = new Page();
         $this->pageRevision = new PageRevision();
+        $this->attachment = new Attachment();
     }
 
     /**
@@ -46,6 +49,7 @@ class EntityProvider
             'book'      => $this->book,
             'chapter'   => $this->chapter,
             'page'      => $this->page,
+            'attachment' => $this->attachment,
         ];
     }
 

--- a/app/Entities/Queries/AttachmentQueries.php
+++ b/app/Entities/Queries/AttachmentQueries.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BookStack\Entities\Queries;
+
+use BookStack\Entities\Models\Entity;
+use BookStack\Entities\Queries\ProvidesEntityQueries;
+use BookStack\Uploads\Attachment;
+use Illuminate\Database\Eloquent\Builder;
+
+class AttachmentQueries implements ProvidesEntityQueries
+{
+
+    protected static array $listAttributes = [
+        'id',
+        'name',
+        'uploaded_to',
+    ];
+
+    public function start(): Builder
+    {
+        return Attachment::query();
+    }
+
+    public function findVisibleById(int $id): ?Entity
+    {
+        return $this->start()->scopes('visible')->find($id);
+    }
+
+    public function visibleForList(): Builder
+    {
+        return $this->start()
+            ->select(array_merge(static::$listAttributes, ['page_slug' => function ($builder) {
+                $builder->select('slug')
+                    ->from('pages')
+                    ->whereColumn('pages.id', '=', 'attachments.uploaded_to');
+            }]));
+    }
+}

--- a/app/Entities/Queries/AttachmentQueries.php
+++ b/app/Entities/Queries/AttachmentQueries.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Builder;
 
 class AttachmentQueries implements ProvidesEntityQueries
 {
-
     protected static array $listAttributes = [
         'id',
         'name',

--- a/app/Entities/Queries/EntityQueries.php
+++ b/app/Entities/Queries/EntityQueries.php
@@ -14,6 +14,7 @@ class EntityQueries
         public ChapterQueries $chapters,
         public PageQueries $pages,
         public PageRevisionQueries $revisions,
+        public AttachmentQueries $attachment,
     ) {
     }
 
@@ -50,6 +51,7 @@ class EntityQueries
             'chapter' => $this->chapters,
             'book' => $this->books,
             'bookshelf' => $this->shelves,
+            'attachment' => $this->attachment,
             default => null,
         };
 

--- a/app/Permissions/PermissionApplicator.php
+++ b/app/Permissions/PermissionApplicator.php
@@ -161,7 +161,9 @@ class PermissionApplicator
         $joinQuery = function ($query) use ($entityProvider) {
             $first = true;
             foreach ($entityProvider->all() as $entity) {
-                if ($entity->getModel()->getTable() === 'attachments') continue;
+                if ($entity->getModel()->getTable() === 'attachments') {
+                    continue;
+                }
                 /** @var Builder $query */
                 $entityQuery = function ($query) use ($entity) {
                     $query->select(['id', 'deleted_at'])

--- a/app/Permissions/PermissionApplicator.php
+++ b/app/Permissions/PermissionApplicator.php
@@ -100,7 +100,7 @@ class PermissionApplicator
     public function restrictEntityQuery(Builder $query): Builder
     {
         return $query->where(function (Builder $parentQuery) {
-            $parentQuery->whereHas('jointPermissions', function (Builder $permissionQuery) {
+            $parentQuery->whereHas($parentQuery->getModel()->getTable() === 'attachments' ? 'attachmentJointPermissions' : 'jointPermissions', function (Builder $permissionQuery) {
                 $permissionQuery->select(['entity_id', 'entity_type'])
                     ->selectRaw('max(owner_id) as owner_id')
                     ->selectRaw('max(status) as status')
@@ -161,6 +161,7 @@ class PermissionApplicator
         $joinQuery = function ($query) use ($entityProvider) {
             $first = true;
             foreach ($entityProvider->all() as $entity) {
+                if ($entity->getModel()->getTable() === 'attachments') continue;
                 /** @var Builder $query */
                 $entityQuery = function ($query) use ($entity) {
                     $query->select(['id', 'deleted_at'])

--- a/app/Search/SearchIndex.php
+++ b/app/Search/SearchIndex.php
@@ -6,6 +6,7 @@ use BookStack\Activity\Models\Tag;
 use BookStack\Entities\EntityProvider;
 use BookStack\Entities\Models\Entity;
 use BookStack\Entities\Models\Page;
+use BookStack\Uploads\Attachment;
 use BookStack\Util\HtmlDocument;
 use DOMNode;
 use Illuminate\Database\Eloquent\Builder;
@@ -68,6 +69,7 @@ class SearchIndex
 
         foreach ($this->entityProvider->all() as $entityModel) {
             $indexContentField = $entityModel instanceof Page ? 'html' : 'description';
+            $indexContentField = $entityModel instanceof Attachment ? 'name' : ($entityModel instanceof Page ? 'html' : 'description');
             $selectFields = ['id', 'name', $indexContentField];
             /** @var Builder<Entity> $query */
             $query = $entityModel->newQuery();

--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -64,7 +64,7 @@ class SearchRunner
 
             $searchQuery = $this->buildQuery($searchOpts, $entityType);
             $entityTotal = $searchQuery->count();
-            $searchResults = $this->getPageOfDataFromQuery($searchQuery, $entityType, $page, $count);            
+            $searchResults = $this->getPageOfDataFromQuery($searchQuery, $entityType, $page, $count);
 
             if ($entityTotal > ($page * $count)) {
                 $hasMore = true;
@@ -182,7 +182,7 @@ class SearchRunner
                 $this->$functionName($entityQuery, $entityModelInstance, $filterOption->value, $filterOption->negated);
             }
         }
-        
+
         return $entityQuery;
     }
 
@@ -260,7 +260,7 @@ class SearchRunner
         if (isset($this->termAdjustmentCache[$options])) {
             return $this->termAdjustmentCache[$options];
         }
-        
+
         $termQuery = SearchTerm::query()->toBase();
         $whenStatements = [];
         $whenBindings = [];

--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -64,7 +64,7 @@ class SearchRunner
 
             $searchQuery = $this->buildQuery($searchOpts, $entityType);
             $entityTotal = $searchQuery->count();
-            $searchResults = $this->getPageOfDataFromQuery($searchQuery, $entityType, $page, $count);
+            $searchResults = $this->getPageOfDataFromQuery($searchQuery, $entityType, $page, $count);            
 
             if ($entityTotal > ($page * $count)) {
                 $hasMore = true;
@@ -135,6 +135,12 @@ class SearchRunner
             };
         }
 
+        if ($entityType === 'attachment') {
+            $relations['page'] = function (BelongsTo $query) {
+                $query->scopes('visible');
+            };
+        }
+
         return $query->clone()
             ->with(array_filter($relations))
             ->skip(($page - 1) * $count)
@@ -176,7 +182,7 @@ class SearchRunner
                 $this->$functionName($entityQuery, $entityModelInstance, $filterOption->value, $filterOption->negated);
             }
         }
-
+        
         return $entityQuery;
     }
 
@@ -254,7 +260,7 @@ class SearchRunner
         if (isset($this->termAdjustmentCache[$options])) {
             return $this->termAdjustmentCache[$options];
         }
-
+        
         $termQuery = SearchTerm::query()->toBase();
         $whenStatements = [];
         $whenBindings = [];

--- a/app/Uploads/Attachment.php
+++ b/app/Uploads/Attachment.php
@@ -2,12 +2,12 @@
 
 namespace BookStack\Uploads;
 
-use BookStack\App\Model;
 use BookStack\Entities\Models\Entity;
 use BookStack\Entities\Models\Page;
 use BookStack\Permissions\Models\JointPermission;
 use BookStack\Permissions\PermissionApplicator;
 use BookStack\Users\Models\HasCreatorAndUpdater;
+use BookStack\Users\Models\HasOwner;
 use BookStack\Users\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -27,16 +27,26 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  *
  * @method static Entity|Builder visible()
  */
-class Attachment extends Model
+class Attachment extends Entity
 {
     use HasCreatorAndUpdater;
     use HasFactory;
+    use HasOwner;
+
+    public string $textField = 'name';
+
+    public string $htmlField = 'name';
 
     protected $fillable = ['name', 'order'];
     protected $hidden = ['path', 'page'];
     protected $casts = [
         'external' => 'bool',
     ];
+
+    public static function bootSoftDeletes()
+    {
+        // No operation: override with an empty method
+    }
 
     /**
      * Get the downloadable file name for this upload.
@@ -55,13 +65,13 @@ class Attachment extends Model
      */
     public function page(): BelongsTo
     {
-        return $this->belongsTo(Page::class, 'uploaded_to');
+        return $this->belongsTo(Page::class, 'uploaded_to')->with(['chapter','book']);
     }
 
-    public function jointPermissions(): HasMany
+    public function attachmentJointPermissions(): HasMany
     {
         return $this->hasMany(JointPermission::class, 'entity_id', 'uploaded_to')
-            ->where('joint_permissions.entity_type', '=', 'page');
+        ->where('joint_permissions.entity_type', '=', 'page');
     }
 
     /**
@@ -110,14 +120,38 @@ class Attachment extends Model
     /**
      * Scope the query to those attachments that are visible based upon related page permissions.
      */
-    public function scopeVisible(): Builder
+    public function scopeVisible(Builder $query): Builder
     {
         $permissions = app()->make(PermissionApplicator::class);
 
         return $permissions->restrictPageRelationQuery(
-            self::query(),
+            $query,
             'attachments',
             'uploaded_to'
         );
+    }
+
+    protected function performDeleteOnModel()
+    {
+        // Perform a direct delete without relying on soft deletes
+        return $this->newQueryWithoutScopes()->where($this->getKeyName(), $this->getKey())->delete();
+    }
+
+    // Prevent soft deletes by setting the deleted column to null
+    public function getDeletedAtColumn()
+    {
+        return null;
+    }
+
+    public function scopeWithTrashed($query)
+    {
+        // No conditions added, so it includes both active and inactive records
+        return $query;
+    }
+
+    public function scopeOnlyTrashed($query)
+    {
+        // No conditions added, so it includes both active and inactive records
+        return $query;
     }
 }

--- a/app/Uploads/AttachmentService.php
+++ b/app/Uploads/AttachmentService.php
@@ -85,7 +85,7 @@ class AttachmentService
      *
      * @throws FileUploadException
      */
-    public function saveNewUpload(UploadedFile $uploadedFile, int $pageId): Attachment
+    public function saveNewUpload(UploadedFile $uploadedFile, int $pageId, int $owned_by): Attachment
     {
         $attachmentName = $uploadedFile->getClientOriginalName();
         $attachmentPath = $this->putFileInStorage($uploadedFile);
@@ -99,6 +99,7 @@ class AttachmentService
             'uploaded_to' => $pageId,
             'created_by'  => user()->id,
             'updated_by'  => user()->id,
+            'owned_by'    => $owned_by,
             'order'       => $largestExistingOrder + 1,
         ]);
 
@@ -132,7 +133,7 @@ class AttachmentService
     /**
      * Save a new File attachment from a given link and name.
      */
-    public function saveNewFromLink(string $name, string $link, int $page_id): Attachment
+    public function saveNewFromLink(string $name, string $link, int $page_id, int $owned_by): Attachment
     {
         $largestExistingOrder = Attachment::where('uploaded_to', '=', $page_id)->max('order');
 
@@ -144,6 +145,7 @@ class AttachmentService
             'uploaded_to' => $page_id,
             'created_by'  => user()->id,
             'updated_by'  => user()->id,
+            'owned_by'    => $owned_by,
             'order'       => $largestExistingOrder + 1,
         ]);
     }

--- a/app/Uploads/Controllers/AttachmentApiController.php
+++ b/app/Uploads/Controllers/AttachmentApiController.php
@@ -28,7 +28,7 @@ class AttachmentApiController extends ApiController
     public function list()
     {
         return $this->apiListingResponse(Attachment::visible(), [
-            'id', 'name', 'extension', 'uploaded_to', 'external', 'order', 'created_at', 'updated_at', 'created_by', 'updated_by',
+            'id', 'name', 'extension', 'uploaded_to', 'external', 'order', 'created_at', 'updated_at', 'created_by', 'updated_by', 'owned_by'
         ]);
     }
 
@@ -54,12 +54,13 @@ class AttachmentApiController extends ApiController
 
         if ($request->hasFile('file')) {
             $uploadedFile = $request->file('file');
-            $attachment = $this->attachmentService->saveNewUpload($uploadedFile, $page->id);
+            $attachment = $this->attachmentService->saveNewUpload($uploadedFile, $page->id, $page->owned_by);
         } else {
             $attachment = $this->attachmentService->saveNewFromLink(
                 $requestData['name'],
                 $requestData['link'],
-                $page->id
+                $page->id,
+                $page->owned_by,
             );
         }
 

--- a/app/Uploads/Controllers/AttachmentController.php
+++ b/app/Uploads/Controllers/AttachmentController.php
@@ -46,7 +46,8 @@ class AttachmentController extends Controller
         $uploadedFile = $request->file('file');
 
         try {
-            $attachment = $this->attachmentService->saveNewUpload($uploadedFile, $pageId);
+            $attachment = $this->attachmentService->saveNewUpload($uploadedFile, $pageId, $page->owned_by);
+            $attachment->indexForSearch();
         } catch (FileUploadException $e) {
             return response($e->getMessage(), 500);
         }
@@ -161,7 +162,7 @@ class AttachmentController extends Controller
 
         $attachmentName = $request->get('attachment_link_name');
         $link = $request->get('attachment_link_url');
-        $this->attachmentService->saveNewFromLink($attachmentName, $link, intval($pageId));
+        $this->attachmentService->saveNewFromLink($attachmentName, $link, intval($pageId), $page->owned_by);
 
         return view('attachments.manager-link-form', [
             'pageId' => $pageId,

--- a/database/migrations/2024_11_07_072714_add_column_owned_by_in_attachments.php
+++ b/database/migrations/2024_11_07_072714_add_column_owned_by_in_attachments.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('attachments', function (Blueprint $table) {
+            $table->integer('owned_by')->after('updated_by');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('attachments', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/entities/list-item-basic.blade.php
+++ b/resources/views/entities/list-item-basic.blade.php
@@ -1,5 +1,5 @@
 <?php $type = $entity->getType(); ?>
-<a href="{{ $entity->getUrl() }}" class="{{$type}} {{$type === 'page' && $entity->draft ? 'draft' : ''}} {{$classes ?? ''}} entity-list-item" data-entity-type="{{$type}}" data-entity-id="{{$entity->id}}">
+<a href="{{ $entity->page ? $entity->page->getUrl() : $entity->getUrl() }}" class="{{$type}} {{$type === 'page' && $entity->draft ? 'draft' : ''}} {{$classes ?? ''}} entity-list-item" data-entity-type="{{$type}}" data-entity-id="{{$entity->id}}">
     <span role="presentation" class="icon text-{{$type}}">@icon($type)</span>
     <div class="content">
             <h4 class="entity-list-item-name break-text">{{ $entity->preview_name ?? $entity->name }}</h4>

--- a/resources/views/entities/list-item.blade.php
+++ b/resources/views/entities/list-item.blade.php
@@ -15,6 +15,15 @@
                 <span class="text-muted entity-list-item-path-sep">@icon('chevron-right')</span> <span class="text-chapter">{{ $entity->chapter->getShortName(42) }}</span>
             @endif
         @endif
+        @if($entity->relationLoaded('page') && $entity->page)
+            <span class="text-page">{{ $entity->page->getShortName(42) }}</span>
+            @if($entity->page->chapter)
+                <span class="text-muted entity-list-item-path-sep">@icon('chevron-right')</span> <span class="text-chapter">{{ $entity->page->chapter->getShortName(42) }}</span>
+                    @if($entity->page->book)
+                        <span class="text-muted entity-list-item-path-sep">@icon('chevron-right')</span> <span class="text-book">{{ $entity->page->book->getShortName(42) }}</span>
+                    @endif
+            @endif
+        @endif
     @endif
 
     <p class="text-muted break-text">{{ $entity->preview_content ?? $entity->getExcerpt() }}</p>

--- a/resources/views/search/all.blade.php
+++ b/resources/views/search/all.blade.php
@@ -27,6 +27,8 @@
                             <br>
                             @include('search.parts.type-filter', ['checked' => !$hasTypes || in_array('book', $types), 'entity' => 'book', 'transKey' => 'book'])
                             @include('search.parts.type-filter', ['checked' => !$hasTypes || in_array('bookshelf', $types), 'entity' => 'bookshelf', 'transKey' => 'shelf'])
+                            <br>
+                            @include('search.parts.type-filter', ['checked' => !$hasTypes || in_array('attachment', $types), 'entity' => 'attachment', 'transKey' => 'attachments'])
                         </div>
 
                         <h6>{{ trans('entities.search_exact_matches') }}</h6>

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -77,6 +77,27 @@ class EntitySearchTest extends TestCase
         $pageTestResp->assertSee($page->name);
     }
 
+    public function test_attachment_search()
+    {
+        $page = $this->entities->page();
+
+        $admin = $this->users->admin();
+        /** @var Attachment $attachment */
+        $attachment = $page->attachments()->forceCreate([
+            'uploaded_to' => $page->id,
+            'name'        => 'My test attachment',
+            'external'    => true,
+            'order'       => 1,
+            'created_by'  => $admin->id,
+            'updated_by'  => $admin->id,
+            'path'        => 'https://attachment.example.com',
+        ]);
+
+        $search = $this->asEditor()->get('/search?term=' . urlencode($attachment->name));
+        $search->assertSee('Search Results');
+        $search->assertSeeText($attachment->name, true);
+    }
+
     public function test_tag_search()
     {
         $newTags = [

--- a/tests/Uploads/AttachmentTest.php
+++ b/tests/Uploads/AttachmentTest.php
@@ -24,6 +24,7 @@ class AttachmentTest extends TestCase
             'order'      => 1,
             'created_by' => $admin->id,
             'updated_by' => $admin->id,
+            'owned_by'   => $page->owned_by,
         ];
 
         $upload = $this->files->uploadAttachmentFile($this, $fileName, $page->id);


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue : [Feature Request] Add "attachments" search filter. 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->
closes #26
## Changes proposed

<!-- List all the proposed changes in your PR -->

- Add Attachment in search filter in content type search 
- Also assign Entity model to Attachment model so that Attachment is also searchable
- Add Test Case for attachment search
- Fix Existing search test cases which is not pass due to changes
- Add "owned_by" column in attachments table to associate each attachment with the owner of its related page

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
